### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==22.2.0
 dnspython==2.6.1
 exceptiongroup==1.1.0
 iniconfig==2.0.0
-packaging==23.0
+packaging>=24.0, <25.0
 pluggy==1.0.0
 pymongo==4.6.3
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="tc-analyzer-lib",
-    version="1.1.0",
+    version="1.1.1",
     author="Mohammad Amin Dadgar, TogetherCrew",
     maintainer="Mohammad Amin Dadgar",
     maintainer_email="dadgaramin96@gmail.com",


### PR DESCRIPTION
This is due to a dependency conflict on airflow-dags repository.

Error was 
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
unstructured-client 0.22.0 requires packaging>=23.1, but you have packaging 23.0 which is incompatible.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `packaging` package version constraint in `requirements.txt` to `>=24.0, <25.0`.
  - Bumped application version from `1.1.0` to `1.1.1` in `setup.py`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->